### PR TITLE
Allow to add additional fields to metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -140,6 +140,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKey(hit, "count", 25);
         assertKey(hit, "name", prefix + ".test.cache-evictions");
+        assertKey(hit, "host", "localhost");
     }
 
     @Test
@@ -159,6 +160,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertKey(hit, "max", 40);
         assertKey(hit, "min", 20);
         assertKey(hit, "mean", 30.0);
+        assertKey(hit, "host", "localhost");
     }
 
     @Test
@@ -175,6 +177,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKey(hit, "name", prefix + ".foo.bar");
         assertKey(hit, "count", 30);
+        assertKey(hit, "host", "localhost");
     }
 
     @Test
@@ -192,6 +195,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKey(hit, "name", prefix + ".foo.bar");
         assertKey(hit, "count", 1);
+        assertKey(hit, "host", "localhost");
     }
 
     @Test
@@ -211,6 +215,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
         assertTimestamp(hit);
         assertKey(hit, "name", prefix + ".foo.bar");
         assertKey(hit, "value", 1234);
+        assertKey(hit, "host", "localhost");
     }
 
     @Test
@@ -364,12 +369,15 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
     }
 
     private ElasticsearchReporter.Builder createElasticsearchReporterBuilder() {
+        Map<String, Object> additionalFields = new HashMap<String, Object>();
+        additionalFields.put("host", "localhost");
         return ElasticsearchReporter.forRegistry(registry)
                 .hosts("localhost:" + getPortOfRunningNode())
                 .prefixedWith(prefix)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .filter(MetricFilter.ALL)
-                .index(index);
+                .index(index)
+                .additionalFields(additionalFields);
     }
 }


### PR DESCRIPTION
allow user to add additional fields to metrics, for example hostname, application name, unique identifier and so on. 
