### PR TITLE
Index name is using as part of index template name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ incomingRequestsMeter.mark(1);
 
 ### Mapping
 
-**Note**: The reporter automatically checks for the existence of an index template called `metrics_template`. If this template does not exist, it is created. This template ensures that all strings used in metrics are set to `not_analyzed` and disables the `_all` field.
+**Note**: The reporter automatically checks for the existence of an index template, defaults to `metrics_template`. If this template does not exist, it is created. This template ensures that all strings used in metrics are set to `not_analyzed` and disables the `_all` field.
 
 
 ## Notifications with percolations

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -460,7 +460,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
      */
     private void checkForIndexTemplate() {
         try {
-            HttpURLConnection connection = openConnection( "/_template/metrics_template", "HEAD");
+            String name = index + "_template";
+            HttpURLConnection connection = openConnection( "/_template/" + name, "HEAD");
             if (connection == null) {
                 LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
                 return;
@@ -472,7 +473,11 @@ public class ElasticsearchReporter extends ScheduledReporter {
             // nothing there, lets create it
             if (isTemplateMissing) {
                 LOGGER.debug("No metrics template found in elasticsearch. Adding...");
-                HttpURLConnection putTemplateConnection = openConnection( "/_template/metrics_template", "PUT");
+                HttpURLConnection putTemplateConnection = openConnection( "/_template/" + name, "PUT");
+                if (putTemplateConnection == null) {
+                    LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
+                    return;
+                }
                 JsonGenerator json = new JsonFactory().createGenerator(putTemplateConnection.getOutputStream());
                 json.writeStartObject();
                 json.writeStringField("template", index + "*");

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -76,7 +76,7 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatTemplateIsAdded() throws Exception {
-        GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates("metrics_template").get();
+        GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates(index + "_template").get();
 
         assertThat(response.getIndexTemplates(), hasSize(1));
         IndexTemplateMetaData templateData = response.getIndexTemplates().get(0);
@@ -114,12 +114,12 @@ public class ElasticsearchReporterTest extends ElasticsearchIntegrationTest {
 
     @Test
     public void testThatTemplateIsNotOverWritten() throws Exception {
-        client().admin().indices().preparePutTemplate("metrics_template").setTemplate("foo*").setSettings(String.format("{ \"index.number_of_shards\" : \"1\"}")).execute().actionGet();
+        client().admin().indices().preparePutTemplate(index + "_template").setTemplate("foo*").setSettings(String.format("{ \"index.number_of_shards\" : \"1\"}")).execute().actionGet();
         //client().admin().cluster().prepareHealth().setWaitForGreenStatus();
 
         elasticsearchReporter = createElasticsearchReporterBuilder().build();
 
-        GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates("metrics_template").get();
+        GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates(index + "_template").get();
 
         assertThat(response.getIndexTemplates(), hasSize(1));
         IndexTemplateMetaData templateData = response.getIndexTemplates().get(0);


### PR DESCRIPTION
It's allow to use reporters with different index names on one Elasticsearch instance.
