### PR TITLE
Upgrade to Elasticsearch 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Metrics Elasticsearch Reporter
 
-This is a reporter for the excellent [metrics library](http://metrics.codahale.com), similar to the [graphite](http://metrics.codahale.com/manual/graphite/) or [ganglia](http://metrics.codahale.com/manual/ganglia/) reporters, except that it reports to an elasticsearch server.
+This is a reporter for the excellent [Metrics library](http://metrics.dropwizard.io/), similar to the [Graphite](http://metrics.dropwizard.io/3.1.0/manual/graphite/) or [Ganglia](http://metrics.dropwizard.io/3.1.0/manual/ganglia/) reporters, except that it reports to an Elasticsearch server.
 
-In case, you are worried, that you need to include the 20MB elasticsearch dependency in your project, you do not need to be. As this reporter is using HTTP for putting data into elasticsearch, the only library needed is the awesome [Jackson JSON library](http://wiki.fasterxml.com/JacksonHome), more exactly the jackson databind library to easily serialize the metrics objects.
+In case, you are worried, that you need to include the 20MB elasticsearch dependency in your project, you do not need to be. As this reporter is using HTTP for putting data into elasticsearch, the only library needed is the awesome [Jackson JSON library](http://wiki.fasterxml.com/JacksonHome), more exactly the Jackson Databind library to easily serialize the metrics objects.
 
-If you want to see this in action, go to the `samples/` directory and read the readme over there, to get up and running with a sample application using the metrics library as well as a dashboard application to graph.
+If you want to see this in action, go to the `samples/` directory and read the readme over there, to get up and running with a sample application using the Metrics library as well as a dashboard application to graph.
 
 ## Compatibility
 
 |   Metrics-elasticsearch-reporter  |    elasticsearch    | Release date |
 |-----------------------------------|---------------------|:------------:|
-| 2.0                               | 1.0.0  -> master    |  2014-02-16  |
+| 3.0.0                             | 2.0.0  -> master    |  2015-XX-XX  |
+| 2.0                               | 1.0.0  -> 1.7.x     |  2014-02-16  |
 | 1.0                               | 0.90.7 -> 0.90.x    |  2014-02-05  |
 
 ## Installation
@@ -21,7 +22,7 @@ You can simply add a dependency in your `pom.xml` (or whatever dependency resolu
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>metrics-elasticsearch-reporter</artifactId>
-  <version>2.0</version>
+  <version>3.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
     <version>3.0.0-SNAPSHOT</version>
 
     <properties>
-        <lucene.version>5.2.1</lucene.version>
-        <elasticsearch.version>2.0.0</elasticsearch.version>
-        <jackson.version>2.5.3</jackson.version>
+        <lucene.version>5.3.1</lucene.version>
+        <elasticsearch.version>2.1.1</elasticsearch.version>
+        <jackson.version>2.6.2</jackson.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,12 @@
     
     <groupId>org.elasticsearch</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
-        <lucene.version>4.10.4</lucene.version>
-        <elasticsearch.version>1.6.0</elasticsearch.version>
+        <lucene.version>5.2.1</lucene.version>
+        <elasticsearch.version>2.0.0</elasticsearch.version>
+        <jackson.version>2.5.3</jackson.version>
     </properties>
 
 
@@ -36,7 +37,7 @@
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
-        <version>7</version>
+        <version>9</version>
     </parent>
 
     <repositories>
@@ -87,12 +88,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-afterburner</artifactId>
-            <version>2.5.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
@@ -116,19 +117,13 @@
         <dependency>
             <groupId>com.carrotsearch.randomizedtesting</groupId>
             <artifactId>randomizedtesting-runner</artifactId>
-            <version>2.1.14</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>2.1.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.12</version>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -136,6 +131,12 @@
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/samples/simple-webapp/pom.xml
+++ b/samples/simple-webapp/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>metrics-elasticsearch-reporter</artifactId>
-            <version>1.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>
@@ -22,7 +22,12 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.3</version>
+            <version>2.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.12</version>
         </dependency>
     </dependencies>
 
@@ -31,16 +36,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.4.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -54,5 +59,5 @@
             </plugin>
         </plugins>
     </build>
-    
+
 </project>

--- a/samples/usa-gov-logfile-parser/pom.xml
+++ b/samples/usa-gov-logfile-parser/pom.xml
@@ -12,22 +12,27 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>0.90.7</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>metrics-elasticsearch-reporter</artifactId>
-            <version>1.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.2.3</version>
+            <version>2.5.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
+            <version>2.5.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.12</version>
         </dependency>
     </dependencies>
 
@@ -36,16 +41,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.4.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
+++ b/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
@@ -18,7 +18,10 @@
  */
 package org.elasticsearch.metrics;
 
-import com.codahale.metrics.*;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -33,11 +36,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.metrics.JsonMetrics.*;
+import static org.elasticsearch.metrics.JsonMetrics.JsonCounter;
+import static org.elasticsearch.metrics.JsonMetrics.JsonGauge;
+import static org.elasticsearch.metrics.JsonMetrics.JsonHistogram;
+import static org.elasticsearch.metrics.JsonMetrics.JsonMeter;
+import static org.elasticsearch.metrics.JsonMetrics.JsonTimer;
 
 public class MetricsElasticsearchModule extends Module {
 
-    public static final Version VERSION = new Version(1, 0, 0, "", "metrics-elasticsearch-reporter", "metrics-elasticsearch-reporter");
+    public static final Version VERSION = new Version(3, 0, 0, "", "metrics-elasticsearch-reporter", "metrics-elasticsearch-reporter");
 
     private static void writeAdditionalFields(final Map<String, Object> additionalFields, final JsonGenerator json) throws IOException {
         if (additionalFields != null) {
@@ -238,7 +245,7 @@ public class MetricsElasticsearchModule extends Module {
      */
     private static class BulkIndexOperationHeaderSerializer extends StdSerializer<BulkIndexOperationHeader> {
 
-        public BulkIndexOperationHeaderSerializer(String timestampFieldname, Map<String, Object> additionalFields) {
+        public BulkIndexOperationHeaderSerializer() {
             super(BulkIndexOperationHeader.class);
         }
 
@@ -297,7 +304,7 @@ public class MetricsElasticsearchModule extends Module {
                 new HistogramSerializer(timestampFieldname, additionalFields),
                 new MeterSerializer(rateUnit, timestampFieldname, additionalFields),
                 new TimerSerializer(rateUnit, durationUnit, timestampFieldname, additionalFields),
-                new BulkIndexOperationHeaderSerializer(timestampFieldname, additionalFields)
+                new BulkIndexOperationHeaderSerializer()
         )));
     }
 


### PR DESCRIPTION
This PR updates the Elasticsearch Metrics reporter to the Elasticsearch 2.0.0 and along the way fixes some minor compiler warnings.