### PR TITLE
Split JSON generation from Elasticsearch sending

### DIFF
--- a/src/main/java/org/elasticsearch/metrics/BaseJsonReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/BaseJsonReporter.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to Elasticsearch under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.metrics;
+
+import com.codahale.metrics.*;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import org.elasticsearch.metrics.percolation.Notifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.elasticsearch.metrics.JsonMetrics.*;
+
+public abstract class BaseJsonReporter extends ScheduledReporter {
+
+    public static abstract class Builder<R extends BaseJsonReporter, B extends Builder<R, B>> {
+        protected final MetricRegistry registry;
+        protected Clock clock;
+        protected String prefix;
+        protected TimeUnit rateUnit;
+        protected TimeUnit durationUnit;
+        protected MetricFilter filter;
+        protected String timestampFieldname = "@timestamp";
+        protected Map<String, Object> additionalFields;
+
+        protected Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.clock = Clock.defaultClock();
+            this.prefix = null;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+        }
+
+        /**
+         * Inject your custom definition of how time passes. Usually the default clock is sufficient
+         */
+        public B withClock(Clock clock) {
+            this.clock = clock;
+            return (B) this;
+        }
+
+        /**
+         * Configure a prefix for each metric name. Optional, but useful to identify single hosts
+         */
+        public B prefixedWith(String prefix) {
+            this.prefix = prefix;
+            return (B) this;
+        }
+
+        /**
+         * Convert all the rates to a certain timeunit, defaults to seconds
+         */
+        public B convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return (B) this;
+        }
+
+        /**
+         * Convert all the durations to a certain timeunit, defaults to milliseconds
+         */
+        public B convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return (B) this;
+        }
+
+        /**
+         * Allows to configure a special MetricFilter, which defines what metrics are reported
+         */
+        public B filter(MetricFilter filter) {
+            this.filter = filter;
+            return (B) this;
+        }
+
+        /**
+         * Configure the name of the timestamp field, defaults to '@timestamp'
+         */
+        public B timestampFieldname(String fieldName) {
+            this.timestampFieldname = fieldName;
+            return (B) this;
+        }
+
+        /**
+         * Additional fields to be included for each metric
+         * @param additionalFields
+         * @return
+         */
+        public B additionalFields(Map<String, Object> additionalFields) {
+            this.additionalFields = additionalFields;
+            return (B) this;
+        }
+
+        public abstract R build() throws IOException;
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseJsonReporter.class);
+
+    private final Clock clock;
+    private final String prefix;
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+    protected final ObjectWriter writer;
+
+    protected BaseJsonReporter(MetricRegistry registry, String name, Clock clock, String prefix, TimeUnit rateUnit, TimeUnit durationUnit,
+                            MetricFilter filter, String timestampFieldname, Map<String, Object> additionalFields) {
+        super(registry, name, filter, rateUnit, durationUnit);
+        this.clock = clock;
+        this.prefix = prefix;
+        if (timestampFieldname == null || timestampFieldname.trim().length() == 0) {
+            LOGGER.error("Timestampfieldname {} is not valid, using default @timestamp", timestampFieldname);
+            timestampFieldname = "@timestamp";
+        }
+
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.configure(SerializationFeature.CLOSE_CLOSEABLE, false);
+        // auto closing means, that the objectmapper is closing after the first write call, which does not work for bulk requests
+        objectMapper.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
+        objectMapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+        objectMapper.registerModule(new AfterburnerModule());
+        objectMapper.registerModule(new MetricsElasticsearchModule(rateUnit, durationUnit, timestampFieldname, additionalFields));
+        writer = objectMapper.writer();
+    }
+
+    protected interface Report {
+        /**
+         * Append metric to report
+         */
+        void add(JsonMetric jsonMetric, AtomicInteger entriesWritten) throws IOException;
+
+        /**
+         * End report, close resources
+         * @throws IOException
+         */
+        void close() throws IOException;
+    }
+
+    /**
+     * Begin report for timestamp
+     */
+    protected abstract Report startReport(long timestamp);
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+
+        // nothing to do if we dont have any metrics to report
+        if (gauges.isEmpty() && counters.isEmpty() && histograms.isEmpty() && meters.isEmpty() && timers.isEmpty()) {
+            LOGGER.info("All metrics empty, nothing to report");
+            return;
+        }
+
+        final long timestamp = clock.getTime() / 1000;
+
+        try {
+            Report report = startReport(timestamp);
+            if (report == null) {
+                LOGGER.error("Could not start report");
+                return;
+            }
+
+            AtomicInteger entriesWritten = new AtomicInteger(0);
+
+            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+                if (entry.getValue().getValue() != null) {
+                    JsonMetric jsonMetric = new JsonGauge(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                    report.add(jsonMetric, entriesWritten);
+                }
+            }
+
+            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+                JsonCounter jsonMetric = new JsonCounter(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                report.add(jsonMetric, entriesWritten);
+            }
+
+            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+                JsonHistogram jsonMetric = new JsonHistogram(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                report.add(jsonMetric, entriesWritten);
+            }
+
+            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+                JsonMeter jsonMetric = new JsonMeter(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                report.add(jsonMetric, entriesWritten);
+            }
+
+            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+                JsonTimer jsonMetric = new JsonTimer(name(prefix, entry.getKey()), timestamp, entry.getValue());
+                report.add(jsonMetric, entriesWritten);
+            }
+
+            report.close();
+        // catch the exception to make sure we do not interrupt the live application
+        } catch (IOException e) {
+            LOGGER.error("Couldnt report to elasticsearch server", e);
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/metrics/BaseJsonReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/BaseJsonReporter.java
@@ -37,8 +37,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.elasticsearch.metrics.JsonMetrics.*;
 
+/**
+ * Base reporter producing metrics in Logstash/JSON format
+ */
 public abstract class BaseJsonReporter extends ScheduledReporter {
 
+    /**
+     * Base reporter builder
+     * @param <R> Reporter class
+     * @param <B> Reporter builder class
+     */
     public static abstract class Builder<R extends BaseJsonReporter, B extends Builder<R, B>> {
         protected final MetricRegistry registry;
         protected Clock clock;
@@ -146,6 +154,9 @@ public abstract class BaseJsonReporter extends ScheduledReporter {
         writer = objectMapper.writer();
     }
 
+    /**
+     * A report contains a batch of metrics and handles resources disposal
+     */
     protected interface Report {
         /**
          * Append metric to report
@@ -218,7 +229,7 @@ public abstract class BaseJsonReporter extends ScheduledReporter {
             report.close();
         // catch the exception to make sure we do not interrupt the live application
         } catch (IOException e) {
-            LOGGER.error("Couldnt report to elasticsearch server", e);
+            LOGGER.error("Couldnt report", e);
         }
     }
 }

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -367,6 +367,10 @@ public class ElasticsearchReporter extends BaseJsonReporter {
                 json.writeObjectField("type", "string");
                 json.writeObjectField("index", "not_analyzed");
                 json.writeEndObject();
+                json.writeObjectFieldStart("type");
+                json.writeObjectField("type", "string");
+                json.writeObjectField("index", "not_analyzed");
+                json.writeEndObject();
                 json.writeEndObject();
                 json.writeEndObject();
 

--- a/src/main/java/org/elasticsearch/metrics/JsonFileReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/JsonFileReporter.java
@@ -1,0 +1,146 @@
+package org.elasticsearch.metrics;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Reporter producing metrics in Logstash/JSON format store them in files (one metric per line).
+ */
+public class JsonFileReporter extends BaseJsonReporter {
+
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    public static class Builder extends BaseJsonReporter.Builder<JsonFileReporter, JsonFileReporter.Builder> {
+        private File directory;
+        private String file = "metrics";
+        private String fileDateFormat = "yyyy-MM";
+        private String fileExtension = "json";
+
+        private Builder(MetricRegistry registry) {
+            super(registry);
+        }
+
+        /**
+         * The directory containing files
+         */
+        public Builder directory(File directory) {
+            this.directory = directory;
+            return this;
+        }
+
+        /**
+         * The file prefix
+         */
+        public Builder file(String file) {
+            this.file = file;
+            return this;
+        }
+
+        /**
+         * The index date format used for rolling files
+         * This is appended to the index name, split by a '-'
+         */
+        public Builder fileDateFormat(String fileDateFormat) {
+            this.fileDateFormat = fileDateFormat;
+            return this;
+        }
+
+        /**
+         * The file extension
+         */
+        public Builder fileExtension(String fileExtension) {
+            this.fileExtension = fileExtension;
+            return this;
+        }
+
+        public JsonFileReporter build() throws IOException {
+            return new JsonFileReporter(registry,
+                    directory,
+                    file,
+                    fileDateFormat,
+                    fileExtension,
+                    clock,
+                    prefix,
+                    rateUnit,
+                    durationUnit,
+                    filter,
+                    timestampFieldname,
+                    additionalFields);
+        }
+
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchReporter.class);
+
+    /**
+     * Directory where files will be written
+     */
+    private final File directory;
+    private final String file;
+    private final DateFormat fileDateFormat;
+    private final String fileExtension;
+
+    public JsonFileReporter(MetricRegistry registry, File directory, String file, String fileDateFormat, String fileExtension, Clock clock, String prefix, TimeUnit rateUnit, TimeUnit durationUnit, MetricFilter filter, String timestampFieldname, Map<String, Object> additionalFields) {
+        super(registry, "json-file-reporter", clock, prefix, rateUnit, durationUnit, filter, timestampFieldname, additionalFields);
+        this.directory = directory;
+        this.file = file;
+        if (fileDateFormat != null && fileDateFormat.length() > 0) {
+            this.fileDateFormat = new SimpleDateFormat(fileDateFormat);
+        } else {
+            this.fileDateFormat = null;
+        }
+        this.fileExtension = fileExtension;
+    }
+
+    private class Report implements BaseJsonReporter.Report {
+        FileOutputStream out;
+
+        public Report(String fileName) throws FileNotFoundException {
+            out = new FileOutputStream(new File(directory, fileName), true);
+        }
+
+        @Override
+        public void add(JsonMetrics.JsonMetric jsonMetric, AtomicInteger entriesWritten) throws IOException {
+            writer.writeValue(out, jsonMetric);
+            out.write("\n".getBytes());
+
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+    }
+
+    @Override
+    protected Report startReport(long timestamp) {
+        String fileName = file;
+        if (fileDateFormat!= null) {
+            fileName += "-" + fileDateFormat.format(new Date(timestamp * 1000));
+        }
+        fileName += "." + fileExtension;
+        try {
+            return new Report(fileName);
+        } catch (FileNotFoundException e) {
+            LOGGER.error("Could not connect write file {}", fileName);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
+++ b/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
@@ -70,6 +70,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", gauge.name());
+            json.writeStringField("type", gauge.type());
             json.writeObjectField(timestampFieldname, gauge.timestampAsDate());
             final Object value;
             try {
@@ -99,6 +100,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", counter.name());
+            json.writeStringField("type", counter.type());
             json.writeObjectField(timestampFieldname, counter.timestampAsDate());
             json.writeNumberField("count", counter.value().getCount());
             writeAdditionalFields(additionalFields, json);
@@ -123,6 +125,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonHistogram.name());
+            json.writeStringField("type", jsonHistogram.type());
             json.writeObjectField(timestampFieldname, jsonHistogram.timestampAsDate());
             Histogram histogram = jsonHistogram.value();
 
@@ -164,6 +167,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonMeter.name());
+            json.writeStringField("type", jsonMeter.type());
             json.writeObjectField(timestampFieldname, jsonMeter.timestampAsDate());
             Meter meter = jsonMeter.value();
             json.writeNumberField("count", meter.getCount());
@@ -201,6 +205,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonTimer.name());
+            json.writeStringField("type", jsonTimer.type());
             json.writeObjectField(timestampFieldname, jsonTimer.timestampAsDate());
             Timer timer = jsonTimer.value();
             final Snapshot snapshot = timer.getSnapshot();

--- a/src/test/java/org/elasticsearch/metrics/JsonFileReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/JsonFileReporterTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to Elasticsearch under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. ElasticSearch licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.metrics;
+
+import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.hasKey;
+
+public class JsonFileReporterTest extends ESIntegTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private JsonFileReporter reporter;
+    private MetricRegistry registry = new MetricRegistry();
+    private String file = randomAsciiOfLength(12).toLowerCase();
+    private String fileExt = randomAsciiOfLength(3).toLowerCase();
+    private String fileWithDate = String.format("%s-%s-%02d.%s", file, Calendar.getInstance().get(Calendar.YEAR), Calendar.getInstance().get(Calendar.MONTH) + 1, fileExt);
+    private String prefix = randomAsciiOfLength(12).toLowerCase();
+    private File directory;
+
+    @Before
+    public void setup() throws IOException {
+        directory = temporaryFolder.newFolder(randomAsciiOfLength(12).toLowerCase());
+        reporter = createJsonFileReporterBuilder().build();
+    }
+
+    private Map<String, Object> parseLine(String line) throws IOException {
+        return JsonXContent.jsonXContent.createParser(line).map();
+    }
+
+    @Test
+    public void testThatTimeBasedIndicesCanBeDisabled() throws Exception {
+        reporter = createJsonFileReporterBuilder().fileDateFormat("").build();
+        fileWithDate = file + "." + fileExt;
+
+        registry.counter(name("test", "cache-evictions")).inc();
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"counter\"");
+        assertThat(searchResponse.size(), is(1));
+    }
+
+    @Test
+    public void testCounter() throws Exception {
+        final Counter evictions = registry.counter(name("test", "cache-evictions"));
+        evictions.inc(25);
+        report();
+
+        // "type":"counter"
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"counter\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertTimestamp(hit);
+        assertKey(hit, "count", 25);
+        assertKey(hit, "name", prefix + ".test.cache-evictions");
+        assertKey(hit, "host", "localhost");
+    }
+
+    @Test
+    public void testHistogram() throws IOException {
+        final Histogram histogram = registry.histogram(name("foo", "bar"));
+        histogram.update(20);
+        histogram.update(40);
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"histogram\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertTimestamp(hit);
+        assertKey(hit, "name", prefix + ".foo.bar");
+        assertKey(hit, "count", 2);
+        assertKey(hit, "max", 40);
+        assertKey(hit, "min", 20);
+        assertKey(hit, "mean", 30.0);
+        assertKey(hit, "host", "localhost");
+    }
+
+    @Test
+    public void testMeter() throws IOException {
+        final Meter meter = registry.meter(name("foo", "bar"));
+        meter.mark(10);
+        meter.mark(20);
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"meter\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertTimestamp(hit);
+        assertKey(hit, "name", prefix + ".foo.bar");
+        assertKey(hit, "count", 30);
+        assertKey(hit, "host", "localhost");
+    }
+
+    @Test
+    public void testTimer() throws Exception {
+        final Timer timer = registry.timer(name("foo", "bar"));
+        final Timer.Context timerContext = timer.time();
+        Thread.sleep(200);
+        timerContext.stop();
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"timer\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertTimestamp(hit);
+        assertKey(hit, "name", prefix + ".foo.bar");
+        assertKey(hit, "count", 1);
+        assertKey(hit, "host", "localhost");
+    }
+
+    @Test
+    public void testGauge() throws Exception {
+        registry.register(name("foo", "bar"), new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1234;
+            }
+        });
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"gauge\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertTimestamp(hit);
+        assertKey(hit, "name", prefix + ".foo.bar");
+        assertKey(hit, "value", 1234);
+        assertKey(hit, "host", "localhost");
+    }
+
+
+    @Test
+    public void testThatTimestampFieldnameCanBeConfigured() throws Exception {
+        reporter = createJsonFileReporterBuilder().timestampFieldname("myTimeStampField").build();
+        registry.counter(name("myMetrics", "cache-evictions")).inc();
+        report();
+
+        List<String> searchResponse = searchLineInFile(fileWithDate, "\"type\":\"counter\"");
+        assertThat(searchResponse.size(), is(1));
+
+        Map<String, Object> hit = parseLine(searchResponse.get(0));
+        assertThat(hit, hasKey("myTimeStampField"));
+    }
+
+    private void report() {
+        reporter.report();
+    }
+
+    private void assertKey(Map<String, Object> hit, String key, double value) {
+        assertKey(hit, key, Double.toString(value));
+    }
+
+    private void assertKey(Map<String, Object> hit, String key, int value) {
+        assertKey(hit, key, Integer.toString(value));
+    }
+
+    private void assertKey(Map<String, Object> hit, String key, String value) {
+        assertThat(hit, hasKey(key));
+        assertThat(hit.get(key).toString(), is(value));
+    }
+
+    private void assertTimestamp(Map<String, Object> hit) {
+        assertThat(hit, hasKey("@timestamp"));
+        // no exception means everything is cool
+        ISODateTimeFormat.dateOptionalTimeParser().parseDateTime(hit.get("@timestamp").toString());
+    }
+
+    private JsonFileReporter.Builder createJsonFileReporterBuilder() throws IOException {
+        Map<String, Object> additionalFields = new HashMap<>();
+        additionalFields.put("host", "localhost");
+        return JsonFileReporter.forRegistry(registry)
+                .directory(directory)
+                .file(file)
+                .fileExtension(fileExt)
+                .prefixedWith(prefix)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .additionalFields(additionalFields);
+    }
+
+    private List<String> searchLineInFile(String fileName, String lineRegex) throws IOException {
+        Pattern pattern = Pattern.compile(lineRegex);
+        List<String> lines = new ArrayList<>();
+        File file = new File(directory, fileName);
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (pattern.matcher(line).find()) {
+                    lines.add(line);
+                }
+            }
+        }
+        return lines;
+    }
+}


### PR DESCRIPTION
I'd like to be able to send metrics using the same pipeline I have for logs (Kafka + Logstash + Elasticsearch) and not directly to Elasticsearch.

I've split the ElasticsearchReporter class in two: BaseJsonReporter produces metrics in JSON format and ElasticsearchReporter send them Elasticsearch. 
I wrote a JsonFileReporter to show I can output metrics to something else using the same format. These files could be read by FileBeat. 
I was forced to had the metric type in the JSON documents.
I plan to write a KafkaReporter for my own needs similar to JsonFileReporter.

I admit this code is far from being production grade, it's more a proof of concept.
Do you think it's a good idea? And provided I take time to improve code, would you accept such a PR?