### PR TITLE
Support Elasticsearch 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ If you want to see this in action, go to the `samples/` directory and read the r
 
 |   Metrics-elasticsearch-reporter  |    elasticsearch    | Release date |
 |-----------------------------------|---------------------|:------------:|
-| 2.3.0-SNAPSHOT                    | 2.3.0  -> master    |  NONE        |
+| 5.1.1-SNAPSHOT                    | 5.0.0  -> 5.1.x     |  master      |
+| 2.3.0                             | 2.3.0  -> 2.4.x     |  TBD         |
 | 2.2.0                             | 2.2.0  -> 2.2.x     |  2016-02-10  |
 | 2.0                               | 1.0.0  -> 1.7.x     |  2014-02-16  |
 | 1.0                               | 0.90.7 -> 0.90.x    |  2014-02-05  |
@@ -27,7 +28,7 @@ You can simply add a dependency in your `pom.xml` (or whatever dependency resolu
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>metrics-elasticsearch-reporter</artifactId>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 
@@ -90,10 +91,25 @@ public class PagerNotifier implements Notifier {
 }
 ```
 
-Add a percolation
+Add a percolation _(elasticsearch < 5.0)_
 
 ```
 curl http://localhost:9200/metrics/.percolator/http-monitor -X PUT -d '{
+  "query" : { 
+    "bool" : { 
+      "must": [
+        { "term": { "name" : "incoming-http-requests" } },
+        { "range": { "m1_rate": { "to" : "10" } } }
+      ]
+    }
+  }
+}'
+```
+
+Add a percolation _(elasticsearch >= 5.0)_
+
+```
+curl http://localhost:9200/metrics/queries/http-monitor -X PUT -d '{
   "query" : { 
     "bool" : { 
       "must": [

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <groupId>org.elasticsearch</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>5.1.1-SNAPSHOT</version>
 
     <properties>
-        <lucene.version>5.5.0</lucene.version>
-        <elasticsearch.version>2.3.1</elasticsearch.version>
+        <lucene.version>6.3.0</lucene.version>
+        <elasticsearch.version>5.1.1</elasticsearch.version>
         <jackson.version>2.7.3</jackson.version>
         <randomized.testrunner.version>2.3.3</randomized.testrunner.version>
+        <log4j.version>2.7</log4j.version>
+        <slf4j.version>1.7.2</slf4j.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>
@@ -19,8 +23,11 @@
     <inceptionYear>2013</inceptionYear>
 
     <scm>
-        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</connection>
-        <developerConnection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</developerConnection>
+        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git
+        </connection>
+        <developerConnection>
+            scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git
+        </developerConnection>
         <url>http://github.com/elasticsearch/elasticsearch-metrics-reporter</url>
     </scm>
 
@@ -97,36 +104,54 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
             <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <groupId>org.elasticsearch.test</groupId>
+            <artifactId>framework</artifactId>
             <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.carrotsearch.randomizedtesting</groupId>
-            <artifactId>randomizedtesting-runner</artifactId>
-            <version>${randomized.testrunner.version}</version>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.19</version>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>percolator-client</artifactId>
+            <version>${elasticsearch.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
@@ -23,11 +21,8 @@
     <inceptionYear>2013</inceptionYear>
 
     <scm>
-        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git
-        </connection>
-        <developerConnection>
-            scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git
-        </developerConnection>
+        <connection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</connection>
+        <developerConnection>scm:git:git@github.com:elasticsearch/elasticsearch-metrics-reporter-java.git</developerConnection>
         <url>http://github.com/elasticsearch/elasticsearch-metrics-reporter</url>
     </scm>
 

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -18,15 +18,7 @@
  */
 package org.elasticsearch.metrics;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.*;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -47,23 +39,12 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedMap;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.elasticsearch.metrics.JsonMetrics.JsonCounter;
-import static org.elasticsearch.metrics.JsonMetrics.JsonGauge;
-import static org.elasticsearch.metrics.JsonMetrics.JsonHistogram;
-import static org.elasticsearch.metrics.JsonMetrics.JsonMeter;
-import static org.elasticsearch.metrics.JsonMetrics.JsonMetric;
-import static org.elasticsearch.metrics.JsonMetrics.JsonTimer;
+import static org.elasticsearch.metrics.JsonMetrics.*;
 import static org.elasticsearch.metrics.MetricsElasticsearchModule.BulkIndexOperationHeader;
 
 public class ElasticsearchReporter extends ScheduledReporter {
@@ -79,7 +60,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         private TimeUnit rateUnit;
         private TimeUnit durationUnit;
         private MetricFilter filter;
-        private String[] hosts = new String[]{"localhost:9200"};
+        private String[] hosts = new String[]{ "localhost:9200" };
         private String index = "metrics";
         private String indexDateFormat = "yyyy-MM";
         private int bulkSize = 2500;
@@ -139,12 +120,13 @@ public class ElasticsearchReporter extends ScheduledReporter {
         }
 
         /**
-         * Configure an array of hosts to send data to. Note: Data is always sent to only one host,
-         * but this makes sure, that even if a part of your elasticsearch cluster is not running,
-         * reporting still happens A host must be in the format hostname:port The port must be the
-         * HTTP port of your elasticsearch instance
+         * Configure an array of hosts to send data to.
+         * Note: Data is always sent to only one host, but this makes sure, that even if a part of your elasticsearch cluster
+         *       is not running, reporting still happens
+         * A host must be in the format hostname:port
+         * The port must be the HTTP port of your elasticsearch instance
          */
-        public Builder hosts(String... hosts) {
+        public Builder hosts(String ... hosts) {
             this.hosts = hosts;
             return this;
         }
@@ -191,8 +173,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         }
 
         /**
-         * An instance of the notifier implemention which should be executed in case of a matching
-         * percolation
+         * An instance of the notifier implemention which should be executed in case of a matching percolation
          */
         public Builder percolationNotifier(Notifier notifier) {
             this.percolationNotifier = notifier;
@@ -209,6 +190,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
 
         /**
          * Additional fields to be included for each metric
+         * @param additionalFields
+         * @return
          */
         public Builder additionalFields(Map<String, Object> additionalFields) {
             this.additionalFields = additionalFields;
@@ -359,7 +342,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                     }
                 }
             }
-            // catch the exception to make sure we do not interrupt the live application
+        // catch the exception to make sure we do not interrupt the live application
         } catch (IOException e) {
             LOGGER.error("Couldnt report to elasticsearch server", e);
         }
@@ -462,14 +445,13 @@ public class ElasticsearchReporter extends ScheduledReporter {
     }
 
     /**
-     * Open a new HttpUrlConnection, in case it fails it tries for the next host in the configured
-     * list
+     * Open a new HttpUrlConnection, in case it fails it tries for the next host in the configured list
      */
     private HttpURLConnection openConnection(String uri, String method) {
         for (String host : hosts) {
             try {
-                URL templateUrl = new URL("http://" + host + uri);
-                HttpURLConnection connection = (HttpURLConnection) templateUrl.openConnection();
+                URL templateUrl = new URL("http://" + host  + uri);
+                HttpURLConnection connection = ( HttpURLConnection ) templateUrl.openConnection();
                 connection.setRequestMethod(method);
                 connection.setConnectTimeout(timeout);
                 connection.setUseCaches(false);
@@ -493,7 +475,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
      */
     private void checkForIndexTemplate() {
         try {
-            HttpURLConnection connection = openConnection("/_template/metrics_template", "HEAD");
+            HttpURLConnection connection = openConnection( "/_template/metrics_template", "HEAD");
             if (connection == null) {
                 LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
                 return;
@@ -505,8 +487,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
             // nothing there, lets create it
             if (isTemplateMissing) {
                 LOGGER.debug("No metrics template found in elasticsearch. Adding...");
-                HttpURLConnection putTemplateConnection = openConnection("/_template/metrics_template", "PUT");
-                if (putTemplateConnection == null) {
+                HttpURLConnection putTemplateConnection = openConnection( "/_template/metrics_template", "PUT");
+                if(putTemplateConnection == null) {
                     LOGGER.error("Error adding metrics template to elasticsearch");
                     return;
                 }

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -41,26 +41,31 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.metrics.percolation.Notifier;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.percolator.PercolatorPlugin;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.Netty4Plugin;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class ElasticsearchReporterTest extends ESIntegTestCase {
 
     private ElasticsearchReporter elasticsearchReporter;
@@ -71,10 +76,20 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return settingsBuilder()
+        return Settings.builder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put(Node.HTTP_ENABLED, true)
+                .put("http.type", "netty4")
+                .put("http.enabled", "true")
+                .put("http.port", "9200-9300")
                 .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(Netty4Plugin.class);
+        plugins.add(PercolatorPlugin.class);
+        return plugins;
     }
 
     @Before
@@ -109,9 +124,10 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         IndexMetaData indexMetaData = clusterStateResponse.getState().getMetaData().getIndices().get(indexWithDate);
         assertThat(indexMetaData.getMappings().containsKey("counter"), is(true));
         Map<String, Object> properties = getAsMap(indexMetaData.mapping("counter").sourceAsMap(), "properties");
+
         Map<String, Object> mapping = getAsMap(properties, "name");
-        assertThat(mapping, hasKey("index"));
-        assertThat(mapping.get("index").toString(), is("not_analyzed"));
+        assertThat(mapping, hasKey("type"));
+        assertThat(mapping.get("type").toString(), is("keyword"));
     }
 
     @SuppressWarnings("unchecked")
@@ -294,8 +310,8 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
                                 .must(QueryBuilders.rangeQuery("count").gte(20))
                                 .must(QueryBuilders.termQuery("name", prefix + ".foo"))
                 );
-        String json = String.format("{ \"query\" : %s }", queryBuilder.buildAsBytes().toUtf8());
-        client().prepareIndex(indexWithDate, ".percolator", "myName").setRefresh(true).setSource(json).execute().actionGet();
+        String json = String.format("{ \"query\" : %s }", queryBuilder);
+        client().prepareIndex(indexWithDate, "queries", "myName").setSource(json).execute().actionGet();
 
         evictions.inc(1);
         reportAndRefresh();

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -124,7 +124,6 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         IndexMetaData indexMetaData = clusterStateResponse.getState().getMetaData().getIndices().get(indexWithDate);
         assertThat(indexMetaData.getMappings().containsKey("counter"), is(true));
         Map<String, Object> properties = getAsMap(indexMetaData.mapping("counter").sourceAsMap(), "properties");
-
         Map<String, Object> mapping = getAsMap(properties, "name");
         assertThat(mapping, hasKey("type"));
         assertThat(mapping.get("type").toString(), is("keyword"));


### PR DESCRIPTION
With ES 5.0+, percolation has changed.  This PR supports the new percolation approach and updates test configuration to work properly with ES 5+.