### PR TITLE
Option to name the field for "value" depending on the type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ incomingRequestsMeter.mark(1);
 * `index()`: The name of the index to write to, defaults to `metrics`
 * `indexDateFormat()`: The date format to make sure to rotate to a new index, defaults to `yyyy-MM`
 * `timestampFieldname()`: The field name of the timestamp, defaults to `@timestamp`, which makes it easy to use with kibana
+* `dynamicValueFieldname()`: Whether the fieldname for `value` should depend on the value type or not. Defaults to `false`, so `value` is used as fieldname. When set to `true`, the fieldname will be one of `['value_string', 'value_long', 'value_double', 'value_boolean', 'value']`. Fallback is `value` when the type is not one of `String`, `Long|Integer`, `Double|Float`, or `Boolean`.  Only used for meters of type gauge. 
 
 ### Mapping
 

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -67,6 +67,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         private int timeout = 1000;
         private String timestampFieldname = "@timestamp";
         private Map<String, Object> additionalFields;
+        private boolean dynamicValueFieldname = false;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -196,7 +197,18 @@ public class ElasticsearchReporter extends ScheduledReporter {
             return this;
         }
 
-        public ElasticsearchReporter build() throws IOException {
+        /**
+         * Whether the fieldname for "value" should depend on the value type or not. Defaults to <code>false</code>.
+         * When set to <code>true</code>, the fieldname for value will be "value_string", "value_long" etc.
+         * @param dynamicValueFieldname
+         * @return
+         */
+        public Builder dynamicValueFieldname(boolean dynamicValueFieldname) {
+			this.dynamicValueFieldname = dynamicValueFieldname;
+			return this;
+		}
+
+		public ElasticsearchReporter build() throws IOException {
             return new ElasticsearchReporter(registry,
                     hosts,
                     timeout,
@@ -211,7 +223,8 @@ public class ElasticsearchReporter extends ScheduledReporter {
                     percolationFilter,
                     percolationNotifier,
                     timestampFieldname,
-                    additionalFields);
+                    additionalFields,
+                    dynamicValueFieldname);
         }
     }
 
@@ -233,7 +246,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
 
     public ElasticsearchReporter(MetricRegistry registry, String[] hosts, int timeout,
                                  String index, String indexDateFormat, int bulkSize, Clock clock, String prefix, TimeUnit rateUnit, TimeUnit durationUnit,
-                                 MetricFilter filter, MetricFilter percolationFilter, Notifier percolationNotifier, String timestampFieldname, Map<String, Object> additionalFields) throws MalformedURLException {
+                                 MetricFilter filter, MetricFilter percolationFilter, Notifier percolationNotifier, String timestampFieldname, Map<String, Object> additionalFields, boolean dynamicValueFieldname) throws MalformedURLException {
         super(registry, "elasticsearch-reporter", filter, rateUnit, durationUnit);
         this.hosts = hosts;
         this.index = index;
@@ -259,7 +272,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
         objectMapper.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         objectMapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
         objectMapper.registerModule(new AfterburnerModule());
-        objectMapper.registerModule(new MetricsElasticsearchModule(rateUnit, durationUnit, timestampFieldname, additionalFields));
+        objectMapper.registerModule(new MetricsElasticsearchModule(rateUnit, durationUnit, timestampFieldname, additionalFields, dynamicValueFieldname));
         writer = objectMapper.writer();
         checkForIndexTemplate();
     }
@@ -490,6 +503,10 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 json.writeEndObject();
                 json.writeObjectFieldStart("properties");
                 json.writeObjectFieldStart("name");
+                json.writeObjectField("type", "string");
+                json.writeObjectField("index", "not_analyzed");
+                json.writeEndObject();
+                json.writeObjectFieldStart("value_string");
                 json.writeObjectField("type", "string");
                 json.writeObjectField("index", "not_analyzed");
                 json.writeEndObject();

--- a/src/test/java/org/elasticsearch/metrics/ValueFieldnameTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ValueFieldnameTest.java
@@ -1,0 +1,129 @@
+package org.elasticsearch.metrics;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.metrics.JsonMetrics.JsonGauge;
+import org.elasticsearch.metrics.JsonMetrics.JsonMetric;
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests if the fieldname for value gets correctly named when dynamicValueFieldname() is set to <code>true</code>.
+ * @author static-max
+ *
+ */
+public class ValueFieldnameTest {
+	
+	@Test
+	public void test() throws JsonProcessingException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new MetricsElasticsearchModule(TimeUnit.MINUTES, TimeUnit.MINUTES, "@timestamp", null, true));
+		
+		Gauge<String> gaugeString = new Gauge<String>() {
+			@Override
+			public String getValue() {
+				return "STRING VALUE";
+			}
+		};
+		
+		/**
+		 * Used for deadlocks in metrics-jvm ThreadStatesGaugeSet.class.
+		 */
+		Gauge<Set<String>> gaugeStringSet = new Gauge<Set<String>>() {
+			@Override
+			public Set<String> getValue() {
+				HashSet<String> testSet = new HashSet<>();
+				testSet.add("1");
+				testSet.add("2");
+				testSet.add("3");
+				return testSet;
+			}
+		};
+		
+		Gauge<Long> gaugeLong = new Gauge<Long>() {
+			
+			@Override
+			public Long getValue() {
+				return Long.MAX_VALUE;
+			}
+		};
+		
+		Gauge<Integer> gaugeInteger = new Gauge<Integer>() {
+			
+			@Override
+			public Integer getValue() {
+				return 123;
+			}
+		};
+		
+		Gauge<Double> gaugeDouble = new Gauge<Double>() {
+			
+			@Override
+			public Double getValue() {
+				return 1.23d;
+			}
+		};
+		
+		Gauge<Float> gaugeFloat = new Gauge<Float>() {
+			
+			@Override
+			public Float getValue() {
+				return 321.0f;
+			}
+		};
+		
+		Gauge<Boolean> gaugeBoolean = new Gauge<Boolean>() {
+			
+			@Override
+			public Boolean getValue() {
+				return true;
+			}
+		};
+		
+		JsonMetric<?> jsonMetricString = new JsonGauge("string", Long.MAX_VALUE, gaugeString);
+		JsonMetric<?> jsonMetricStringSet = new JsonGauge("stringSet", Long.MAX_VALUE, gaugeStringSet);
+		JsonMetric<?> jsonMetricLong = new JsonGauge("long", Long.MAX_VALUE, gaugeLong);
+		JsonMetric<?> jsonMetricInteger = new JsonGauge("integer", Long.MAX_VALUE, gaugeInteger);
+		JsonMetric<?> jsonMetricDouble = new JsonGauge("double", Long.MAX_VALUE, gaugeDouble);
+		JsonMetric<?> jsonMetricFloat = new JsonGauge("float", Long.MAX_VALUE, gaugeFloat);
+		JsonMetric<?> jsonMetricBoolean = new JsonGauge("boolean", Long.MAX_VALUE, gaugeBoolean);
+        		
+		JsonNode stringNode = objectMapper.valueToTree(jsonMetricString);
+		assertTrue(stringNode.get("value_string").isTextual());
+		assertFalse(stringNode.get("value_string").isNumber());
+		
+		JsonNode stringSetNode = objectMapper.valueToTree(jsonMetricStringSet);
+		assertTrue(stringSetNode.get("value_string").isTextual());
+		assertFalse(stringSetNode.get("value_string").isNumber());		
+		
+		JsonNode longNode = objectMapper.valueToTree(jsonMetricLong);
+		assertTrue(longNode.get("value_long").isNumber());
+		assertFalse(longNode.get("value_long").isTextual());
+		
+		JsonNode integerNode = objectMapper.valueToTree(jsonMetricInteger);
+		assertTrue(integerNode.get("value_long").isNumber());
+		assertFalse(integerNode.get("value_long").isTextual());
+		
+		JsonNode doubleNode = objectMapper.valueToTree(jsonMetricDouble);
+		assertTrue(doubleNode.get("value_double").isNumber());
+		assertTrue(doubleNode.get("value_double").isDouble());
+		
+		JsonNode floatNode = objectMapper.valueToTree(jsonMetricFloat);
+		assertTrue(floatNode.get("value_double").isNumber());
+		assertTrue(floatNode.get("value_double").isDouble());
+		
+		JsonNode booleanNode = objectMapper.valueToTree(jsonMetricBoolean);
+		assertTrue(booleanNode.get("value_boolean").isBoolean());
+		assertFalse(booleanNode.get("value_boolean").isTextual());		
+	}
+
+}
+

--- a/src/test/java/org/elasticsearch/metrics/ValueFieldnameTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ValueFieldnameTest.java
@@ -89,7 +89,6 @@ public class ValueFieldnameTest {
 		};
 		
 		JsonMetric<?> jsonMetricString = new JsonGauge("string", Long.MAX_VALUE, gaugeString);
-		JsonMetric<?> jsonMetricStringSet = new JsonGauge("stringSet", Long.MAX_VALUE, gaugeStringSet);
 		JsonMetric<?> jsonMetricLong = new JsonGauge("long", Long.MAX_VALUE, gaugeLong);
 		JsonMetric<?> jsonMetricInteger = new JsonGauge("integer", Long.MAX_VALUE, gaugeInteger);
 		JsonMetric<?> jsonMetricDouble = new JsonGauge("double", Long.MAX_VALUE, gaugeDouble);
@@ -99,10 +98,6 @@ public class ValueFieldnameTest {
 		JsonNode stringNode = objectMapper.valueToTree(jsonMetricString);
 		assertTrue(stringNode.get("value_string").isTextual());
 		assertFalse(stringNode.get("value_string").isNumber());
-		
-		JsonNode stringSetNode = objectMapper.valueToTree(jsonMetricStringSet);
-		assertTrue(stringSetNode.get("value_string").isTextual());
-		assertFalse(stringSetNode.get("value_string").isNumber());		
 		
 		JsonNode longNode = objectMapper.valueToTree(jsonMetricLong);
 		assertTrue(longNode.get("value_long").isNumber());


### PR DESCRIPTION
This opions allows to name the "value" field depending of the type of the value. Supports numerical (integer, long, double, float), string and boolean datatypes.
This will address #28 and #10.