### PR TITLE
Add support for an ingest pipeline and resource file loading for configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ If you want to see this in action, go to the `samples/` directory and read the r
 
 |   Metrics-elasticsearch-reporter  |    elasticsearch    | Release date |
 |-----------------------------------|---------------------|:------------:|
-| 2.3.0-SNAPSHOT                    | 2.3.0  -> master    |  NONE        |
+| 5.1.1-SNAPSHOT                    | 5.0.0  -> 5.1.x     |  master      |
+| 2.3.0                             | 2.3.0  -> 2.4.x     |  TBD         |
 | 2.2.0                             | 2.2.0  -> 2.2.x     |  2016-02-10  |
 | 2.0                               | 1.0.0  -> 1.7.x     |  2014-02-16  |
 | 1.0                               | 0.90.7 -> 0.90.x    |  2014-02-05  |
@@ -27,7 +28,7 @@ You can simply add a dependency in your `pom.xml` (or whatever dependency resolu
 <dependency>
   <groupId>org.elasticsearch</groupId>
   <artifactId>metrics-elasticsearch-reporter</artifactId>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 
@@ -90,10 +91,25 @@ public class PagerNotifier implements Notifier {
 }
 ```
 
-Add a percolation
+Add a percolation _(elasticsearch < 5.0)_
 
 ```
 curl http://localhost:9200/metrics/.percolator/http-monitor -X PUT -d '{
+  "query" : { 
+    "bool" : { 
+      "must": [
+        { "term": { "name" : "incoming-http-requests" } },
+        { "range": { "m1_rate": { "to" : "10" } } }
+      ]
+    }
+  }
+}'
+```
+
+Add a percolation _(elasticsearch >= 5.0)_
+
+```
+curl http://localhost:9200/metrics/queries/http-monitor -X PUT -d '{
   "query" : { 
     "bool" : { 
       "must": [
@@ -194,4 +210,3 @@ This is how the serialized metrics looks like in elasticsearch
 ## Next steps
 
 * Integration with Kibana would be awesome
-

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ incomingRequestsMeter.mark(1);
 * `index()`: The name of the index to write to, defaults to `metrics`
 * `indexDateFormat()`: The date format to make sure to rotate to a new index, defaults to `yyyy-MM`
 * `timestampFieldname()`: The field name of the timestamp, defaults to `@timestamp`, which makes it easy to use with kibana
+* `templateResource()`: The path to a resource file containing the index template
+* `ingestPipeline()`: An ingest pipeline to use at document creation
+* `pipelineResource()`: The path to a resource file containing an ingest pipeline definition
+* `scriptResources()`: A list of paths to resources containing one or more scripts (intended to be associated with the ingest pipeline) 
 
 ### Mapping
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <groupId>org.elasticsearch</groupId>
     <artifactId>metrics-elasticsearch-reporter</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>5.1.1-SNAPSHOT</version>
 
     <properties>
-        <lucene.version>5.5.0</lucene.version>
-        <elasticsearch.version>2.3.1</elasticsearch.version>
+        <lucene.version>6.3.0</lucene.version>
+        <elasticsearch.version>5.1.1</elasticsearch.version>
         <jackson.version>2.7.3</jackson.version>
         <randomized.testrunner.version>2.3.3</randomized.testrunner.version>
+        <log4j.version>2.7</log4j.version>
+        <slf4j.version>1.7.2</slf4j.version>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>
@@ -97,36 +99,54 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-test-framework</artifactId>
             <version>${lucene.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
+            <groupId>org.elasticsearch.test</groupId>
+            <artifactId>framework</artifactId>
             <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.carrotsearch.randomizedtesting</groupId>
-            <artifactId>randomizedtesting-runner</artifactId>
-            <version>${randomized.testrunner.version}</version>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.19</version>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${elasticsearch.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>percolator-client</artifactId>
+            <version>${elasticsearch.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -33,8 +33,7 @@ import org.elasticsearch.metrics.percolation.Notifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -69,6 +68,10 @@ public class ElasticsearchReporter extends ScheduledReporter {
         private int timeout = 1000;
         private String timestampFieldname = "@timestamp";
         private Map<String, Object> additionalFields;
+        private String templateResource;
+        private String ingestPipeline;
+        private String pipelineResource;
+        private List<String> scriptResources;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -198,6 +201,55 @@ public class ElasticsearchReporter extends ScheduledReporter {
             return this;
         }
 
+        /**
+         * The path to a resource containing the index template.  If a metrics index does not exist, the
+         * configuration contained in this resource will be used to configure the metrics index. The resource
+         * must be in JSON format as specified in the Elasticsearch documentation for index template definition.
+         *
+         * @param templateResource
+         */
+        public Builder templateResource(String templateResource) {
+            this.templateResource = templateResource;
+            return this;
+        }
+
+        /**
+         * The name of an ingest pipeline to be associated with inserts.
+         *
+         * @param ingestPipeline the pipeline name
+         */
+        public Builder ingestPipeline(String ingestPipeline) {
+            this.ingestPipeline = ingestPipeline;
+            return this;
+        }
+
+        /**
+         * The path to a resource containing an ingest pipeline definition. This may be used in conjunction with
+         * <code>ingestPipeline</code> in defining an ingest pipeline to execute upon document insertion.  Text
+         * prior to any file extension is used as the pipeline id.  If the file does not have an extension, the
+         * entire file name is used as the pipeline id. The resource must be in JSON format as specified in the
+         * Elasticsearch documentation for ingest pipeline definition.
+         *
+         * @param pipelineResource
+         */
+        public Builder pipelineResource(String pipelineResource) {
+            this.pipelineResource = pipelineResource;
+            return this;
+        }
+
+        /**
+         * A list of paths to resources containing one or more scripts. This allows for defining scripts that
+         * may be required as part of an ingest pipeline. When defining the scripts, Text prior to any file extension
+         * is used as the script id. The file extension is used to identify the script language. If no extension is
+         * specified, the entire file name is used as the script id, and the language defaults to painless.
+         *
+         * @param scriptResources
+         */
+        public Builder scriptResources(List<String> scriptResources) {
+            this.scriptResources = scriptResources;
+            return this;
+        }
+
         public ElasticsearchReporter build() throws IOException {
             return new ElasticsearchReporter(registry,
                     hosts,
@@ -213,7 +265,11 @@ public class ElasticsearchReporter extends ScheduledReporter {
                     percolationFilter,
                     percolationNotifier,
                     timestampFieldname,
-                    additionalFields);
+                    additionalFields,
+                    templateResource,
+                    ingestPipeline,
+                    pipelineResource,
+                    scriptResources);
         }
     }
 
@@ -232,10 +288,16 @@ public class ElasticsearchReporter extends ScheduledReporter {
     private String currentIndexName;
     private SimpleDateFormat indexDateFormat = null;
     private boolean checkedForIndexTemplate = false;
+    private final String templateResource;
+    private final String ingestPipeline;
+    private final String pipelineResource;
+    private final List<String> scriptResources;
+
 
     public ElasticsearchReporter(MetricRegistry registry, String[] hosts, int timeout,
                                  String index, String indexDateFormat, int bulkSize, Clock clock, String prefix, TimeUnit rateUnit, TimeUnit durationUnit,
-                                 MetricFilter filter, MetricFilter percolationFilter, Notifier percolationNotifier, String timestampFieldname, Map<String, Object> additionalFields) throws MalformedURLException {
+                                 MetricFilter filter, MetricFilter percolationFilter, Notifier percolationNotifier, String timestampFieldname, Map<String, Object> additionalFields,
+                                 String templateResource, String ingestPipeline, String pipelineResource, List<String> scriptResources) throws MalformedURLException {
         super(registry, "elasticsearch-reporter", filter, rateUnit, durationUnit);
         this.hosts = hosts;
         this.index = index;
@@ -263,6 +325,12 @@ public class ElasticsearchReporter extends ScheduledReporter {
         objectMapper.registerModule(new AfterburnerModule());
         objectMapper.registerModule(new MetricsElasticsearchModule(rateUnit, durationUnit, timestampFieldname, additionalFields));
         writer = objectMapper.writer();
+
+        this.templateResource = templateResource;
+        this.ingestPipeline = ingestPipeline;
+        this.pipelineResource = pipelineResource;
+        this.scriptResources = scriptResources;
+
         checkForIndexTemplate();
     }
 
@@ -436,7 +504,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
      * serialize a JSON metric over the outputstream in a bulk request
      */
     private void writeJsonMetric(JsonMetric jsonMetric, ObjectWriter writer, OutputStream out) throws IOException {
-        writer.writeValue(out, new BulkIndexOperationHeader(currentIndexName, jsonMetric.type()));
+        writer.writeValue(out, new BulkIndexOperationHeader(currentIndexName, jsonMetric.type(), ingestPipeline));
         out.write("\n".getBytes());
         writer.writeValue(out, jsonMetric);
         out.write("\n".getBytes());
@@ -475,7 +543,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
      */
     private void checkForIndexTemplate() {
         try {
-            HttpURLConnection connection = openConnection( "/_template/metrics_template", "HEAD");
+            HttpURLConnection connection = openConnection("/_template/metrics_template", "HEAD");
             if (connection == null) {
                 LOGGER.error("Could not connect to any configured elasticsearch instances: {}", Arrays.asList(hosts));
                 return;
@@ -487,49 +555,193 @@ public class ElasticsearchReporter extends ScheduledReporter {
             // nothing there, lets create it
             if (isTemplateMissing) {
                 LOGGER.debug("No metrics template found in elasticsearch. Adding...");
-                HttpURLConnection putTemplateConnection = openConnection( "/_template/metrics_template", "PUT");
-                if(putTemplateConnection == null) {
-                    LOGGER.error("Error adding metrics template to elasticsearch");
-                    return;
+                if (!loadResourceTemplate()) {
+                    loadDefaultTemplate();
                 }
-                LOGGER.info("Creating metrics template matching index pattern of {}", index + "*");
-                JsonGenerator json = new JsonFactory().createGenerator(putTemplateConnection.getOutputStream());
-                json.writeStartObject();
-                json.writeStringField("template", index + "*");
-                json.writeObjectFieldStart("mappings");
 
-                json.writeObjectFieldStart("_default_");
-                json.writeObjectFieldStart("_all");
-                json.writeBooleanField("enabled", false);
-                json.writeEndObject();
-                json.writeObjectFieldStart("properties");
-                json.writeObjectFieldStart("name");
-                json.writeObjectField("type", "keyword");
-                json.writeEndObject();
-                json.writeEndObject();
-                json.writeEndObject();
-
-                //Percolator - ES 5.0+ changed how percolation queries are handled. Now need to be part of the mapping
-                json.writeObjectFieldStart("queries");
-                json.writeObjectFieldStart("properties");
-                json.writeObjectFieldStart("query");
-                json.writeStringField("type", "percolator");
-                json.writeEndObject();
-                json.writeEndObject();
-                json.writeEndObject();
-
-                json.writeEndObject();
-                json.writeEndObject();
-                json.flush();
-
-                putTemplateConnection.disconnect();
-                if (putTemplateConnection.getResponseCode() != 200) {
-                    LOGGER.error("Error adding metrics template to elasticsearch: {}/{}", putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
-                }
+                loadResourcePipeline();
+                loadScriptResources();
             }
             checkedForIndexTemplate = true;
         } catch (IOException e) {
-            LOGGER.error("Error when checking/adding metrics template to elasticsearch", e);
+            LOGGER.error("Error checking metrics template.", e);
+        }
+    }
+
+    private void loadDefaultTemplate() {
+        try {
+            HttpURLConnection putTemplateConnection = openConnection("/_template/metrics_template", "PUT");
+            if (putTemplateConnection == null) {
+                LOGGER.error("Error adding metrics template to elasticsearch");
+                return;
+            }
+            LOGGER.info("Creating metrics template matching index pattern of {}", index + "*");
+            JsonGenerator json = new JsonFactory().createGenerator(putTemplateConnection.getOutputStream());
+            json.writeStartObject();
+            json.writeStringField("template", index + "*");
+            json.writeObjectFieldStart("mappings");
+
+            json.writeObjectFieldStart("_default_");
+            json.writeObjectFieldStart("_all");
+            json.writeBooleanField("enabled", false);
+            json.writeEndObject();
+            json.writeObjectFieldStart("properties");
+            json.writeObjectFieldStart("name");
+            json.writeObjectField("type", "keyword");
+            json.writeEndObject();
+            json.writeEndObject();
+            json.writeEndObject();
+
+            //Percolator - ES 5.0+ changed how percolation queries are handled. Now need to be part of the mapping
+            json.writeObjectFieldStart("queries");
+            json.writeObjectFieldStart("properties");
+            json.writeObjectFieldStart("query");
+            json.writeStringField("type", "percolator");
+            json.writeEndObject();
+            json.writeEndObject();
+            json.writeEndObject();
+
+            json.writeEndObject();
+            json.writeEndObject();
+            json.flush();
+
+            putTemplateConnection.getOutputStream().close();
+            putTemplateConnection.disconnect();
+            if (putTemplateConnection.getResponseCode() != 200) {
+                LOGGER.error("Error adding metrics template to elasticsearch: {}/{}", putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error creating metrics template in elasticsearch", e);
+        }
+    }
+
+    private boolean loadResourceTemplate() {
+        try {
+            if (templateResource != null && !templateResource.isEmpty()) {
+                LOGGER.info("Loading template resource {}", templateResource);
+                sendResource("/_template/metrics_template", templateResource);
+                return true;
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error adding template resource to elasticsearch", e);
+        }
+
+        return false;
+    }
+
+    private void loadResourcePipeline() {
+        try {
+            if (pipelineResource != null && !pipelineResource.isEmpty()) {
+                LOGGER.info("Loading pipeline resource {}", pipelineResource);
+
+                String pipelineId;
+                int slashPos = pipelineResource.lastIndexOf('/');
+                if (slashPos != -1) {
+                    pipelineId = pipelineResource.substring(slashPos + 1);
+                } else {
+                    pipelineId = pipelineResource;
+                }
+
+                int extensionPos = pipelineId.lastIndexOf('.');
+                if (extensionPos != -1) {
+                    pipelineId = pipelineId.substring(0, extensionPos);
+                }
+
+                sendResource("/_ingest/pipeline/" + pipelineId, pipelineResource);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error adding pipeline resource to elasticsearch", e);
+        }
+    }
+
+    private void loadScriptResources() {
+        try {
+            if (scriptResources != null && !scriptResources.isEmpty()) {
+                LOGGER.info("Loading script resources.");
+
+                for (String scriptResource : scriptResources) {
+                    LOGGER.info("Loading script resource {}", scriptResource);
+
+                    String scriptId;
+                    String language = "painless";
+
+                    int slashPos = scriptResource.lastIndexOf('/');
+                    if (slashPos != -1) {
+                        scriptId = scriptResource.substring(slashPos + 1);
+                    } else {
+                        scriptId = scriptResource;
+                    }
+
+                    int extensionPos = scriptId.lastIndexOf('.');
+                    if (extensionPos != -1) {
+                        language = scriptId.substring(extensionPos + 1);
+                        scriptId = scriptId.substring(0, extensionPos);
+                    }
+
+                    // Read script and produce a single line version for submission
+                    StringBuilder script = new StringBuilder();
+
+                    try (
+                            BufferedReader reader = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream(scriptResource)));
+                    ) {
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            script.append(line);
+                        }
+                    }
+
+                    String inlinedScript = script.toString();
+
+                    LOGGER.debug("Inlined script:");
+                    LOGGER.debug(inlinedScript);
+
+                    String scriptUri = "/_scripts/" + language + '/' + scriptId;
+                    LOGGER.debug("Script URI {}.", scriptUri);
+                    HttpURLConnection postScriptConnection = openConnection(scriptUri, "POST");
+                    if (postScriptConnection == null) {
+                        LOGGER.error("Error adding script resource to elasticsearch");
+                        return;
+                    }
+
+                    JsonGenerator json = new JsonFactory().createGenerator(postScriptConnection.getOutputStream());
+                    json.writeStartObject();
+                    json.writeStringField("script", inlinedScript);
+                    json.writeEndObject();
+                    json.flush();
+
+                    postScriptConnection.getOutputStream().close();
+                    postScriptConnection.disconnect();
+                    if (postScriptConnection.getResponseCode() != 200) {
+                        LOGGER.error("Error adding script resource to elasticsearch: {}/{}", postScriptConnection.getResponseCode(), postScriptConnection.getResponseMessage());
+                    }
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error("Error adding script resource to elasticsearch", e);
+        }
+    }
+
+    private void sendResource(String uri, String resourcePath) throws IOException {
+        LOGGER.debug("Resource Uri {}.", uri);
+        HttpURLConnection esConnection = openConnection(uri, "PUT");
+
+        if (esConnection != null) {
+            try (
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(esConnection.getOutputStream()));
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream(resourcePath)));
+            ) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    writer.write(line);
+                }
+            }
+
+            esConnection.disconnect();
+            if (esConnection.getResponseCode() != 200) {
+                LOGGER.error("Error sending resource to elasticsearch: {}/{}", esConnection.getResponseCode(), esConnection.getResponseMessage());
+            }
+        } else {
+            throw new IOException("Error establishing connection to elasticsearch.");
         }
     }
 }

--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -22,11 +22,13 @@ import com.codahale.metrics.*;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+
 import org.elasticsearch.metrics.percolation.Notifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,7 +251,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
             this.notifier = percolationNotifier;
         }
         if (timestampFieldname == null || timestampFieldname.trim().length() == 0) {
-            LOGGER.error("Timestampfieldname {} is not valid, using default @timestamp", timestampFieldname);
+            LOGGER.error("Timestampfieldname {} is not valid, using default @timestamp", timestampFieldname);
             timestampFieldname = "@timestamp";
         }
 
@@ -340,7 +342,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                     }
                 }
             }
-        // catch the exception to make sure we do not interrupt the live application
+            // catch the exception to make sure we do not interrupt the live application
         } catch (IOException e) {
             LOGGER.error("Couldnt report to elasticsearch server", e);
         }
@@ -350,28 +352,40 @@ public class ElasticsearchReporter extends ScheduledReporter {
      * Execute a percolation request for the specified metric
      */
     private List<String> getPercolationMatches(JsonMetric jsonMetric) throws IOException {
-        HttpURLConnection connection = openConnection("/" + currentIndexName + "/" + jsonMetric.type() + "/_percolate", "POST");
+        HttpURLConnection connection = openConnection("/" + currentIndexName + "/_search", "POST");
         if (connection == null) {
             LOGGER.error("Could not connect to any configured elasticsearch instances for percolation: {}", Arrays.asList(hosts));
             return Collections.emptyList();
         }
 
-        Map<String, Object> data = new HashMap<>(1);
-        data.put("doc", jsonMetric);
-        objectMapper.writeValue(connection.getOutputStream(), data);
+        JsonGenerator json = new JsonFactory().createGenerator(connection.getOutputStream());
+        json.setCodec(objectMapper);
+        json.writeStartObject();
+        json.writeObjectFieldStart("query");
+        json.writeObjectFieldStart("percolate");
+        json.writeStringField("field", "query");
+        json.writeStringField("document_type", jsonMetric.type());
+        json.writeObjectField("document", jsonMetric);
+        json.writeEndObject();
+        json.writeEndObject();
+        json.writeEndObject();
+        json.flush();
+
         closeConnection(connection);
 
         if (connection.getResponseCode() != 200) {
             throw new RuntimeException("Error percolating " + jsonMetric);
         }
 
-        Map<String, Object> input = objectMapper.readValue(connection.getInputStream(), new TypeReference<Map<String, Object>>() {});
         List<String> matches = new ArrayList<>();
-        if (input.containsKey("matches") && input.get("matches") instanceof List) {
-            List<Map<String, String>> foundMatches = (List<Map<String, String>>) input.get("matches");
-            for (Map<String, String> entry : foundMatches) {
-                if (entry.containsKey("_id")) {
-                    matches.add(entry.get("_id"));
+        JsonNode input = objectMapper.readTree(connection.getInputStream());
+        if (input.has("hits")) {
+            JsonNode hits = input.get("hits");
+            if (hits.has("hits") && hits.get("hits").isArray()) {
+                for (JsonNode entry : (ArrayNode) hits.get("hits")) {
+                    if (entry.has("_id")) {
+                        matches.add(entry.get("_id").asText());
+                    }
                 }
             }
         }
@@ -478,7 +492,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                     LOGGER.error("Error adding metrics template to elasticsearch");
                     return;
                 }
-
+                LOGGER.info("Creating metrics template matching index pattern of {}", index + "*");
                 JsonGenerator json = new JsonFactory().createGenerator(putTemplateConnection.getOutputStream());
                 json.writeStartObject();
                 json.writeStringField("template", index + "*");
@@ -490,8 +504,16 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 json.writeEndObject();
                 json.writeObjectFieldStart("properties");
                 json.writeObjectFieldStart("name");
-                json.writeObjectField("type", "string");
-                json.writeObjectField("index", "not_analyzed");
+                json.writeObjectField("type", "keyword");
+                json.writeEndObject();
+                json.writeEndObject();
+                json.writeEndObject();
+
+                //Percolator - ES 5.0+ changed how percolation queries are handled. Now need to be part of the mapping
+                json.writeObjectFieldStart("queries");
+                json.writeObjectFieldStart("properties");
+                json.writeObjectFieldStart("query");
+                json.writeStringField("type", "percolator");
                 json.writeEndObject();
                 json.writeEndObject();
                 json.writeEndObject();
@@ -502,7 +524,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
 
                 putTemplateConnection.disconnect();
                 if (putTemplateConnection.getResponseCode() != 200) {
-                    LOGGER.error("Error adding metrics template to elasticsearch: {}/{}" + putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
+                    LOGGER.error("Error adding metrics template to elasticsearch: {}/{}", putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
                 }
             }
             checkedForIndexTemplate = true;

--- a/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
+++ b/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
@@ -259,6 +259,9 @@ public class MetricsElasticsearchModule extends Module {
             if (bulkIndexOperationHeader.type != null) {
                 json.writeStringField("_type", bulkIndexOperationHeader.type);
             }
+            if (bulkIndexOperationHeader.ingestPipeline != null) {
+                json.writeStringField("pipeline", bulkIndexOperationHeader.ingestPipeline);
+            }
             json.writeEndObject();
             json.writeEndObject();
         }
@@ -267,10 +270,12 @@ public class MetricsElasticsearchModule extends Module {
     public static class BulkIndexOperationHeader {
         public String index;
         public String type;
+        public String ingestPipeline;
 
-        public BulkIndexOperationHeader(String index, String type) {
+        public BulkIndexOperationHeader(String index, String type, String ingestPipeline) {
             this.index = index;
             this.type = type;
+            this.ingestPipeline = ingestPipeline;
         }
     }
 

--- a/src/test/resources/org/elasticsearch/metrics/metrics-ingest.painless
+++ b/src/test/resources/org/elasticsearch/metrics/metrics-ingest.painless
@@ -1,0 +1,1 @@
+ctx.test = "Hello World";

--- a/src/test/resources/org/elasticsearch/metrics/metrics-pipeline.json
+++ b/src/test/resources/org/elasticsearch/metrics/metrics-pipeline.json
@@ -1,0 +1,10 @@
+{
+  "description": "metrics-pipeline",
+  "processors": [
+    {
+      "script": {
+        "id": "metrics-ingest"
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/elasticsearch/metrics/metrics-template.json
+++ b/src/test/resources/org/elasticsearch/metrics/metrics-template.json
@@ -1,0 +1,22 @@
+{
+  "template": "testing*",
+  "mappings": {
+    "_default_": {
+      "_all": {
+        "enabled": false
+      },
+      "properties": {
+        "testMapping": {
+          "type": "keyword"
+        }
+      }
+    },
+    "queries": {
+      "properties": {
+        "query": {
+          "type": "percolator"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I've added support to have documents run through an ingestion pipeline at indexing time.  My use case is to add metadata when creating the meters and parse that metadata into additional fields at index time. An example being:

The original meter name field may look like this:

`field1:value1|field2:value2|field3:value3`

At index time, this metadata is processed into specific fields.  Fo example:

`...`
`"attributes": {`
`    "field1": "value1",`
`    "field2": "value2",`
`    "field3": "value3"`
`}`
`...`

In addition, for meter index and pipeline configuration, I added support for loading these at startup time.

_Note: This code does work.  Unfortunately, even though they're written, I cannot get the pipeline definition and the script loading unit tests to work.  I debugged into the test code, and the Elasticsearch API states that script support has not been enabled.  In looking through the various test sources, I was not able to see how add this support in a straightforward manner._

_Note 2: Before I started my work, I manually copied/merged the files from @mfranklin's pull request (48) in order to keep the 5.x additions from getting out of hand from a merge perspective._