### PR TITLE
add Content-Type header to avoid warnings in ES v5.3.0

### DIFF
--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -441,6 +441,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 connection.setRequestMethod(method);
                 connection.setConnectTimeout(timeout);
                 connection.setUseCaches(false);
+                connection.setRequestProperty("Content-Type", "application/json");
                 if (method.equalsIgnoreCase("POST") || method.equalsIgnoreCase("PUT")) {
                     connection.setDoOutput(true);
                 }


### PR DESCRIPTION
see [Content Type](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#_content_type_auto_detection)