### PR TITLE
Support ElasticSearch 6

### DIFF
--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -439,6 +439,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 URL templateUrl = new URL("http://" + host  + uri);
                 HttpURLConnection connection = ( HttpURLConnection ) templateUrl.openConnection();
                 connection.setRequestMethod(method);
+				connection.setRequestProperty("Content-Type", "application/json");
                 connection.setConnectTimeout(timeout);
                 connection.setUseCaches(false);
                 if (method.equalsIgnoreCase("POST") || method.equalsIgnoreCase("PUT")) {


### PR DESCRIPTION
Add application/json to request to support ElasticSearch 6.

See https://www.elastic.co/blog/strict-content-type-checking-for-elasticsearch-rest-requests for more details.