### PR TITLE
Elasticsearch 6

### DIFF
--- a/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
+++ b/src/main/java/org/elasticsearch/metrics/ElasticsearchReporter.java
@@ -439,6 +439,7 @@ public class ElasticsearchReporter extends ScheduledReporter {
                 URL templateUrl = new URL("http://" + host  + uri);
                 HttpURLConnection connection = ( HttpURLConnection ) templateUrl.openConnection();
                 connection.setRequestMethod(method);
+                connection.setRequestProperty("Content-Type", "application/json");
                 connection.setConnectTimeout(timeout);
                 connection.setUseCaches(false);
                 if (method.equalsIgnoreCase("POST") || method.equalsIgnoreCase("PUT")) {

--- a/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
+++ b/src/main/java/org/elasticsearch/metrics/MetricsElasticsearchModule.java
@@ -70,6 +70,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", gauge.name());
+            json.writeObjectField("metricsType", gauge.type());
             json.writeObjectField(timestampFieldname, gauge.timestampAsDate());
             final Object value;
             try {
@@ -99,6 +100,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", counter.name());
+            json.writeObjectField("metricsType", counter.type());
             json.writeObjectField(timestampFieldname, counter.timestampAsDate());
             json.writeNumberField("count", counter.value().getCount());
             writeAdditionalFields(additionalFields, json);
@@ -123,6 +125,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonHistogram.name());
+            json.writeObjectField("metricsType", jsonHistogram.type());
             json.writeObjectField(timestampFieldname, jsonHistogram.timestampAsDate());
             Histogram histogram = jsonHistogram.value();
 
@@ -164,6 +167,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonMeter.name());
+            json.writeObjectField("metricsType", jsonMeter.type());
             json.writeObjectField(timestampFieldname, jsonMeter.timestampAsDate());
             Meter meter = jsonMeter.value();
             json.writeNumberField("count", meter.getCount());
@@ -201,6 +205,7 @@ public class MetricsElasticsearchModule extends Module {
                               SerializerProvider provider) throws IOException {
             json.writeStartObject();
             json.writeStringField("name", jsonTimer.name());
+            json.writeObjectField("metricsType", jsonTimer.type());
             json.writeObjectField(timestampFieldname, jsonTimer.timestampAsDate());
             Timer timer = jsonTimer.value();
             final Snapshot snapshot = timer.getSnapshot();
@@ -257,7 +262,7 @@ public class MetricsElasticsearchModule extends Module {
                 json.writeStringField("_index", bulkIndexOperationHeader.index);
             }
             if (bulkIndexOperationHeader.type != null) {
-                json.writeStringField("_type", bulkIndexOperationHeader.type);
+                json.writeStringField("_type", "metrics");
             }
             json.writeEndObject();
             json.writeEndObject();

--- a/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
+++ b/src/test/java/org/elasticsearch/metrics/ElasticsearchReporterTest.java
@@ -107,8 +107,8 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
 
         assertThat(clusterStateResponse.getState().getMetaData().getIndices().containsKey(indexWithDate), is(true));
         IndexMetaData indexMetaData = clusterStateResponse.getState().getMetaData().getIndices().get(indexWithDate);
-        assertThat(indexMetaData.getMappings().containsKey("counter"), is(true));
-        Map<String, Object> properties = getAsMap(indexMetaData.mapping("counter").sourceAsMap(), "properties");
+        assertThat(indexMetaData.getMappings().containsKey("metrics"), is(true));
+        Map<String, Object> properties = getAsMap(indexMetaData.mapping("metrics").sourceAsMap(), "properties");
         Map<String, Object> mapping = getAsMap(properties, "name");
         assertThat(mapping, hasKey("index"));
         assertThat(mapping.get("index").toString(), is("not_analyzed"));
@@ -142,7 +142,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         registry.counter(name("test", "cache-evictions")).inc();
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(index).setTypes("counter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(index). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
     }
 
@@ -152,7 +152,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         evictions.inc(25);
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("counter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
@@ -169,7 +169,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         histogram.update(40);
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("histogram").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
@@ -189,7 +189,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         meter.mark(20);
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("meter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
@@ -207,7 +207,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         timerContext.stop();
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("timer").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
@@ -227,7 +227,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         });
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("gauge").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();
@@ -244,7 +244,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         registry.counter(name("test", "cache-evictions")).inc();
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("counter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
     }
 
@@ -264,7 +264,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         }
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("counter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(2020L));
     }
 
@@ -325,7 +325,7 @@ public class ElasticsearchReporterTest extends ESIntegTestCase {
         registry.counter(name("myMetrics", "cache-evictions")).inc();
         reportAndRefresh();
 
-        SearchResponse searchResponse = client().prepareSearch(indexWithDate).setTypes("counter").execute().actionGet();
+        SearchResponse searchResponse = client().prepareSearch(indexWithDate). setTypes("metrics").execute().actionGet();
         assertThat(searchResponse.getHits().totalHits(), is(1L));
 
         Map<String, Object> hit = searchResponse.getHits().getAt(0).sourceAsMap();


### PR DESCRIPTION
This changes set the content-type to `application/json` for all requests and set the `_type` to `metrics` because elasticsearch 6 doesn't support multiple mapping type anymore (https://www.elastic.co/guide/en/elasticsearch/reference/6.0/breaking-changes-6.0.html).

I added a new field `metrcisType` to replace the old `_type` if someone is using it, but that's a breaking change I think.